### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ domain.](http://unlicense.org)
 |   Device      |   Status     |   Factory    |   Sysupgrade |
 |:-------------:|:------------:|:------------:|:------------:|
 | [Bullet M2HP](https://www.ubnt.com/airmax/bulletm/#specs)  | `Working`    |     Yes      |     Yes      |
+| [PowerBeam M5-400](https://openwrt.org/toh/hwdata/ubiquiti/ubiquiti_powerbeam_m5-400) | `Working` | No | Yes |
 
 We currently have access to just one type of device so can't confirm if similar approach might work on other devices with same airOS version. Feel free to test it and let us know.
 


### PR DESCRIPTION
Installed OWRT successfully on my PowerBeam M5-400 with AirOS > v6.1.7

- Downgraded to airOS v6.1.7
- tried flashing owrt factory image -> failed
  (http://downloads.openwrt.org/releases/19.07.7/targets/ar71xx/generic/openwrt-19.07.7-ar71xx-generic-ubnt-rocket-m-xw-squashfs-factory.bin)
- tried flashing owrt sysupgrade -> worked fine :)
  (http://downloads.openwrt.org/releases/19.07.7/targets/ar71xx/generic/openwrt-19.07.7-ar71xx-generic-ubnt-rocket-m-xw-squashfs-sysupgrade.bin)